### PR TITLE
Fix loading IntervenableModel for its subclasses

### DIFF
--- a/pyreft/reft_model.py
+++ b/pyreft/reft_model.py
@@ -13,6 +13,19 @@ class ReftModel(pv.IntervenableModel):
     def __init__(self, config, model, **kwargs):
         super().__init__(config, model, **kwargs)
 
+    @staticmethod
+    def _convert_to_reft_model(intervenable_model):
+        reft_model = ReftModel(intervenable_model.config, intervenable_model.model)
+        # Copy any other necessary attributes
+        for attr in vars(intervenable_model):
+            setattr(reft_model, attr, getattr(intervenable_model, attr))
+        return reft_model
+
+    @staticmethod
+    def load(*args, **kwargs):
+        model = pv.IntervenableModel.load(*args, **kwargs)
+        return ReftModel._convert_to_reft_model(model)
+
     def print_trainable_parameters(self):
         """
         Print trainable parameters.


### PR DESCRIPTION
Fix issue #45
One way is to replicate Pyvene's load() function in Pyreft. That is not great, because later if we modify Pyvene's load(), Pyreft()'s load() could be left behind.
Other way is to replicate all parameters of Pyvene's intervenable_model, which is what this PR does.