### PR TITLE
Title: Fix: Shape Mismatch during Left Padding Adjustment in compute_metrics (Generated by Ana - AI SDE)

### DIFF
--- a/examples/loreft/compute_metrics.py
+++ b/examples/loreft/compute_metrics.py
@@ -175,9 +175,12 @@ def compute_metrics(
             else:
                 # get left padding count, [batch_size], and add to locations
                 left_padding = (inputs["input_ids"] == tokenizer.bos_token_id).nonzero(as_tuple=True)[1]
-                left_padding = left_padding.reshape(1, -1, 1).to(device) # [1, batch_size, 1]
-                intervention_locations += left_padding
-                intervention_locations -= 1 # offset for the sink padding
+                if left_padding.numel() > 0:
+                    left_padding = left_padding.reshape(1, -1, 1).to(device) # [1, batch_size, 1]
+                    intervention_locations += left_padding
+                    intervention_locations -= 1 # offset for the sink padding
+                else:
+                    print("Warning: No BOS token found, skipping left padding adjustment.")
 
                 # repeat each batch by num_beams times in intervention locations
                 # -> [layers, batch_size * num_beams, positions]


### PR DESCRIPTION
## Description:

Fix for [Issue 88](https://github.com/stanfordnlp/pyreft/issues/88)

This pull request addresses a `RuntimeError` caused by a shape mismatch during the left padding adjustment in the `compute_metrics` function of `examples/loreft/compute_metrics.py`. The issue arises when the `left_padding` tensor is empty, leading to an incompatible broadcasting operation with the `intervention_locations` tensor.

This patch was generated by [Ana - AI SDE](https://openana.ai/), an AI-powered software development assistant. 

The fix introduces a check for the presence of elements in `left_padding`. If `left_padding` is empty, a warning message is printed, and the adjustment is skipped. This ensures the compatibility of tensor shapes and prevents the `RuntimeError`.

This patch improves the robustness of the `compute_metrics` function by handling edge cases related to left padding. 
