### PR TITLE
Fix: datasets.exceptions.DatasetNotFoundError when training with alpaca_data_cleaned

### DIFF
--- a/examples/loreft/dataset.py
+++ b/examples/loreft/dataset.py
@@ -103,7 +103,7 @@ class LoReftSupervisedDataset(ReftDataset):
             self.data_path = "main" # huggingface dir.
             if self.data_split != "test":
                 self.data_split = "train" # we split l300 examples from train for validation.
-        elif self.task in ["math", "commonsense", "ultrafeedback"]:
+        elif self.task in ["math", "commonsense", "ultrafeedback", "alpaca"]:
             self.data_path = os.path.join(self.data_path, self.data_split + ".json")
 
     def postprocess(self, kwargs):

--- a/examples/loreft/load_datasets.sh
+++ b/examples/loreft/load_datasets.sh
@@ -9,6 +9,8 @@ mkdir dataset/commonsense_170k
 mv LLM-Adapters/ft-training_set/commonsense_170k.json dataset/commonsense_170k/train.json
 mkdir dataset/math_10k
 mv LLM-Adapters/ft-training_set/math_10k.json dataset/math_10k/train.json
+mkdir dataset/alpaca_data_cleaned
+mv LLM-Adapters/ft-training_set/alpaca_data_cleaned.json dataset/alpaca_data_cleaned/train.json
 mkdir dataset/ultrafeedback
 mv ultrafeedback-dataset/train.json dataset/ultrafeedback/train.json
 


### PR DESCRIPTION
Running
```bash
python train.py -task alpaca \
    -data_dir dataset \
    -model meta-llama/Llama-2-7b-hf \
    -seed 42 -l "3;9;18;24" -r 4 -p f5+l5 -e 9 -lr 9e-4 \
    -type LoreftIntervention \
    -gradient_accumulation_steps 32 \
    -batch_size 4 \
    -eval_batch_size 2 \
    --test_split test \
    --use_normalized_template \
    --max_length 768
```
gives an error:
```
task: alpaca, model: meta-llama/Llama-2-7b-hf, intervention_type: LoreftIntervention, layers: 3;9;18;24, rank: 4, position: f5+l5, epoch: 9, train_on_inputs: False, max_length: 768, allow_cls_grad: False
{'num_interventions': 8, 'position': 'f5+l5', 'share_weights': False, 'test_split': 'test'}
loading data for dataset:  dataset/alpaca_data_cleaned
Traceback (most recent call last):
  File "/home/pyreft/examples/loreft/train.py", line 523, in <module>
    main()
  File "/home/pyreft/examples/loreft/train.py", line 519, in main
    finetune(**vars(args), args=args)
  File "/home/pyreft/examples/loreft/train.py", line 203, in finetune
    train_dataset = ReftDataset(
                    ^^^^^^^^^^^^
  File "/home/miniconda3/envs/pyreft/lib/python3.11/site-packages/pyreft/dataset.py", line 152, in __init__
    self.task_dataset = self.load_dataset()
                        ^^^^^^^^^^^^^^^^^^^
  File "/home/miniconda3/envs/pyreft/lib/python3.11/site-packages/pyreft/dataset.py", line 194, in load_dataset
    task_dataset = load_dataset(self.task, self.data_path, split=self.data_split)
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/miniconda3/envs/pyreft/lib/python3.11/site-packages/datasets/load.py", line 2556, in load_dataset
    builder_instance = load_dataset_builder(
                       ^^^^^^^^^^^^^^^^^^^^^
  File "/home/miniconda3/envs/pyreft/lib/python3.11/site-packages/datasets/load.py", line 2228, in load_dataset_builder
    dataset_module = dataset_module_factory(
                     ^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/miniconda3/envs/pyreft/lib/python3.11/site-packages/datasets/load.py", line 1873, in dataset_module_factory
    raise e1 from None
  File "/home/miniconda3/envs/pyreft/lib/python3.11/site-packages/datasets/load.py", line 1815, in dataset_module_factory
    raise DatasetNotFoundError(msg + f" at revision '{revision}'" if revision else msg)
datasets.exceptions.DatasetNotFoundError: Dataset 'alpaca' doesn't exist on the Hub or cannot be accessed
```
This PR is for the issue https://github.com/stanfordnlp/pyreft/issues/107. Assuming that the alpaca_data_cleaned comes from https://github.com/aryamanarora/LLM-Adapters/blob/main/ft-training_set/alpaca_data_cleaned.json, the fix seems to resolve the error
```task: alpaca, model: meta-llama/Llama-2-7b-hf, intervention_type: LoreftIntervention, layers: 3;9;18;24, rank: 4, position: f5+l5, epoch: 9, train_on_inputs: False, max_length: 768, allow_cls_grad: False
{'num_interventions': 8, 'position': 'f5+l5', 'share_weights': False, 'test_split': 'test'}
loading data for dataset:  dataset/alpaca_data_cleaned/train.json
100%|████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 51759/51759 [01:18<00:00, 656.47it/s]
{'num_interventions': 8, 'position': 'f5+l5', 'share_weights': False}
loading data for dataset:  alpaca_eval
/home/miniconda3/envs/pyreft/lib/python3.11/site-packages/datasets/load.py:1461: FutureWarning: The repository for tatsu-lab/alpaca_eval contains custom code which must be executed to correctly load the dataset. You can inspect the repository content at https://hf.co/datasets/tatsu-lab/alpaca_eval
You can avoid this message in future by passing the argument `trust_remote_code=True`.
Passing `trust_remote_code=True` will be mandatory to load this dataset from the next major release of `datasets`.
  warnings.warn(
100%|███████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 805/805 [00:00<00:00, 1475.52it/s]
Loading checkpoint shards: 100%|██████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████████| 2/2 [00:05<00:00,  2.78s/it]
trainable intervention params: 262,176 || trainable model params: 0
model params: 6,738,415,616 || trainable%: 0.003890766241510503
Detected kernel version 5.4.0, which is below the recommended minimum of 5.5.0; this can cause the process to hang. It is recommended to upgrade the kernel to the minimum version or higher.
{'loss': 1.2636, 'grad_norm': 0.7435398101806641, 'learning_rate': 0.0008997524752475247, 'epoch': 0.0}                                                                                                                                                 
{'loss': 1.2252, 'grad_norm': 1.693534016609192, 'learning_rate': 0.0008995049504950495, 'epoch': 0.0}                                                                                                                                                  
{'loss': 1.2639, 'grad_norm': 2.3768346309661865, 'learning_rate': 0.0008992574257425742, 'epoch': 0.01}                                                                                                                                                
{'loss': 1.1711, 'grad_norm': 0.9159371852874756, 'learning_rate': 0.000899009900990099, 'epoch': 0.01}                                                                                                                                                 
{'loss': 1.1202, 'grad_norm': 0.5363260507583618, 'learning_rate': 0.0008987623762376237, 'epoch': 0.01}                                                                                                                                                
{'loss': 1.2434, 'grad_norm': 0.42779675126075745, 'learning_rate': 0.0008985148514851486, 'epoch': 0.01}                                                                                                                                               
{'loss': 1.1735, 'grad_norm': 0.34404969215393066, 'learning_rate': 0.0008982673267326733, 'epoch': 0.02}                                                                                                                                               
{'loss': 1.1307, 'grad_norm': 0.27842792868614197, 'learning_rate': 0.0008980198019801981, 'epoch': 0.02} 
```