### PR TITLE
Feat: marker-based intervention positions and first-class ReFT DPO trainer

### DIFF
--- a/pyreft/__init__.py
+++ b/pyreft/__init__.py
@@ -12,7 +12,8 @@ from .reft_trainer import (
     ReftTrainer,
     ReftTrainerForCausalLM,
     ReftTrainerForCausalLMDistributed,
-    ReftTrainerForSequenceClassification
+    ReftTrainerForSequenceClassification,
+    ReftDPOTrainer,
 )
 
 # interventions
@@ -35,8 +36,11 @@ from .dataset import (
     ReftPreferenceDataset,
     ReftRewardDataset,
     ReftRewardCollator,
+    ReftDPODataCollator,
     make_last_position_supervised_data_module,
     make_multiple_position_supervised_data_module,
+    make_marker_supervised_data_module,
+    make_dpo_data_module,
     get_intervention_locations,
-    parse_positions
+    parse_positions,
 )

--- a/pyreft/dataset.py
+++ b/pyreft/dataset.py
@@ -109,6 +109,156 @@ def get_intervention_locations(**kwargs):
     return intervention_locations
 
 
+def _parse_marker_spans(
+    text: str,
+    start_marker: str = "<<reft>>",
+    end_marker: str = "</reft>>",
+) -> tuple:
+    """Extract spans between markers and return cleaned text with span (start, end) char offsets in cleaned text."""
+    cleaned_parts = []
+    spans = []
+    pos = 0
+    while True:
+        s = text.find(start_marker, pos)
+        if s < 0:
+            cleaned_parts.append(text[pos:])
+            break
+        cleaned_parts.append(text[pos:s])
+        e = text.find(end_marker, s + len(start_marker))
+        if e < 0:
+            cleaned_parts.append(text[s:])
+            break
+        span_content = text[s + len(start_marker):e]
+        start_in_cleaned = sum(len(p) for p in cleaned_parts)
+        end_in_cleaned = start_in_cleaned + len(span_content)
+        spans.append((start_in_cleaned, end_in_cleaned))
+        cleaned_parts.append(span_content)
+        pos = e + len(end_marker)
+    cleaned_text = "".join(cleaned_parts)
+    return cleaned_text, spans
+
+
+def _span_ranges_to_token_indices(
+    tokenizer: transformers.PreTrainedTokenizer,
+    text: str,
+    span_ranges: List[tuple],
+    model_max_length: Optional[int] = None,
+) -> List[List[int]]:
+    """Map character span ranges in text to token indices. Returns one list of token indices per span."""
+    enc = tokenizer(
+        text,
+        max_length=model_max_length or tokenizer.model_max_length,
+        truncation=True,
+        return_offsets_mapping=True,
+        return_tensors=None,
+    )
+    offset_mapping = enc.get("offset_mapping")
+    if not offset_mapping:
+        enc = tokenizer(
+            text,
+            max_length=model_max_length or tokenizer.model_max_length,
+            truncation=True,
+            return_offsets_mapping=True,
+        )
+        offset_mapping = enc["offset_mapping"]
+    input_ids = enc["input_ids"] if isinstance(enc.get("input_ids")[0], int) else enc["input_ids"][0]
+    if hasattr(input_ids, "tolist"):
+        input_ids = input_ids.tolist()
+    token_indices_per_span = []
+    for start_char, end_char in span_ranges:
+        indices = []
+        for i, (tok_start, tok_end) in enumerate(offset_mapping):
+            if tok_start is None or tok_end is None:
+                continue
+            if tok_start < end_char and tok_end > start_char:
+                indices.append(i)
+        token_indices_per_span.append(indices if indices else [len(input_ids) - 1])
+    return token_indices_per_span
+
+
+def make_marker_supervised_data_module(
+    tokenizer: transformers.PreTrainedTokenizer,
+    model,
+    inputs: List[str],
+    outputs: List[str],
+    start_marker: str = "<<reft>>",
+    end_marker: str = "</reft>>",
+    num_interventions: int = 1,
+    nonstop: bool = False,
+    intervene_on_last_token_of_span_only: bool = False,
+) -> Dict:
+    """Build supervised data module from prompts that contain marker spans for intervention targeting.
+
+    Prompts may include spans wrapped in start_marker/end_marker (e.g. <<reft>> ... </reft>>).
+    Markers are stripped from the actual input; intervention_locations are set to token indices
+    of the marked spans (or only the last token of each span if intervene_on_last_token_of_span_only).
+    """
+    all_base_input_ids = []
+    all_intervention_locations = []
+    all_output_ids = []
+    max_len = getattr(tokenizer, "model_max_length", None) or 2048
+    for i in range(len(inputs)):
+        prompt = inputs[i]
+        output = outputs[i]
+        cleaned_prompt, span_ranges = _parse_marker_spans(prompt, start_marker, end_marker)
+        if not span_ranges:
+            base_prompt_length = len(
+                tokenizer(
+                    cleaned_prompt,
+                    max_length=max_len,
+                    truncation=True,
+                    return_tensors="pt",
+                )["input_ids"][0]
+            )
+            span_token_lists = [[base_prompt_length - 1]]
+        else:
+            span_token_lists = _span_ranges_to_token_indices(
+                tokenizer, cleaned_prompt, span_ranges, max_len
+            )
+            if intervene_on_last_token_of_span_only:
+                span_token_lists = [[s[-1]] if s else [0] for s in span_token_lists]
+        full_input = cleaned_prompt + output
+        if not nonstop:
+            full_input += tokenizer.eos_token
+        base_input_ids = tokenizer(
+            full_input,
+            max_length=max_len,
+            truncation=True,
+            return_tensors="pt",
+        )["input_ids"][0]
+        prompt_ids = tokenizer(
+            cleaned_prompt,
+            max_length=max_len,
+            truncation=True,
+            return_tensors="pt",
+        )["input_ids"][0]
+        base_prompt_length = len(prompt_ids)
+        output_ids = copy.deepcopy(base_input_ids)
+        output_ids[:base_prompt_length] = IGNORE_INDEX
+        flat_positions = []
+        for sl in span_token_lists:
+            flat_positions.extend(sl)
+        if not flat_positions:
+            flat_positions = [base_prompt_length - 1]
+        intervention_locations = [flat_positions] * num_interventions
+        all_base_input_ids.append(base_input_ids)
+        all_intervention_locations.append(intervention_locations)
+        all_output_ids.append(output_ids)
+    train_dataset = datasets.Dataset.from_dict({
+        "input_ids": all_base_input_ids,
+        "intervention_locations": all_intervention_locations,
+        "labels": all_output_ids,
+    })
+    data_collator_fn = transformers.DataCollatorForSeq2Seq(
+        tokenizer=tokenizer,
+        model=model,
+        label_pad_token_id=-100,
+        padding="longest",
+    )
+    data_collator = ReftDataCollator(data_collator=data_collator_fn)
+    return dict(train_dataset=train_dataset, eval_dataset=None, data_collator=data_collator)
+
+
 @dataclass
 class ReftDataCollator(object):
     """Collate examples for ReFT."""
@@ -799,3 +949,115 @@ class ReftRewardCollator:
         max_seq_length = batch["input_ids"].shape[-1]
         batch["intervention_locations"] = batch["intervention_locations"][..., :max_seq_length]
         return batch
+
+
+@dataclass
+class ReftDPODataCollator:
+    """Collator for DPO training: tokenizes prompt/chosen/rejected and adds intervention_locations."""
+
+    tokenizer: transformers.PreTrainedTokenizer
+    max_length: int = 512
+    max_prompt_length: Optional[int] = None
+    num_interventions: int = 1
+    pad_token_id: Optional[int] = None
+
+    def __call__(self, features: List[Dict[str, Any]]) -> Dict[str, Any]:
+        pad_id = self.pad_token_id if self.pad_token_id is not None else self.tokenizer.pad_token_id
+        max_pl = self.max_prompt_length or self.max_length
+        chosen_input_ids, chosen_attention_mask, chosen_labels = [], [], []
+        rejected_input_ids, rejected_attention_mask, rejected_labels = [], [], []
+        intervention_locations_batch = []
+        for f in features:
+            prompt, chosen, rejected = f["prompt"], f["chosen"], f["rejected"]
+            prompt_enc = self.tokenizer(
+                prompt,
+                max_length=max_pl,
+                truncation=True,
+                return_tensors="pt",
+            )
+            prompt_ids = prompt_enc["input_ids"][0]
+            prompt_len = prompt_ids.shape[0]
+            chosen_full = prompt + chosen + (self.tokenizer.eos_token or "")
+            chosen_enc = self.tokenizer(
+                chosen_full,
+                max_length=self.max_length,
+                truncation=True,
+                return_tensors="pt",
+            )
+            c_ids = chosen_enc["input_ids"][0]
+            c_labels = copy.deepcopy(c_ids)
+            c_labels[:prompt_len] = IGNORE_INDEX
+            rejected_full = prompt + rejected + (self.tokenizer.eos_token or "")
+            rejected_enc = self.tokenizer(
+                rejected_full,
+                max_length=self.max_length,
+                truncation=True,
+                return_tensors="pt",
+            )
+            r_ids = rejected_enc["input_ids"][0]
+            r_labels = copy.deepcopy(r_ids)
+            r_labels[:prompt_len] = IGNORE_INDEX
+            chosen_input_ids.append(c_ids)
+            chosen_attention_mask.append((c_ids != pad_id).long())
+            chosen_labels.append(c_labels)
+            rejected_input_ids.append(r_ids)
+            rejected_attention_mask.append((r_ids != pad_id).long())
+            rejected_labels.append(r_labels)
+            intervention_locations_batch.append([[prompt_len - 1]] * self.num_interventions)
+        to_pad = lambda x, pad_val: torch.nn.utils.rnn.pad_sequence(
+            x, batch_first=True, padding_value=pad_val
+        )
+        chosen_input_ids = to_pad(chosen_input_ids, pad_id)
+        chosen_attention_mask = to_pad(chosen_attention_mask, 0)
+        chosen_labels = to_pad(chosen_labels, IGNORE_INDEX)
+        rejected_input_ids = to_pad(rejected_input_ids, pad_id)
+        rejected_attention_mask = to_pad(rejected_attention_mask, 0)
+        rejected_labels = to_pad(rejected_labels, IGNORE_INDEX)
+        num_int, max_pos = len(intervention_locations_batch[0]), max(
+            len(p[0]) for p in intervention_locations_batch
+        )
+        il_tensor = torch.full(
+            (len(features), num_int, max_pos), -1, dtype=torch.long
+        )
+        for i, locs in enumerate(intervention_locations_batch):
+            for j, pos_list in enumerate(locs):
+                il_tensor[i, j, : len(pos_list)] = torch.tensor(pos_list, dtype=torch.long)
+        return {
+            "chosen_input_ids": chosen_input_ids,
+            "chosen_attention_mask": chosen_attention_mask,
+            "chosen_labels": chosen_labels,
+            "rejected_input_ids": rejected_input_ids,
+            "rejected_attention_mask": rejected_attention_mask,
+            "rejected_labels": rejected_labels,
+            "intervention_locations": il_tensor,
+        }
+
+
+def make_dpo_data_module(
+    tokenizer: transformers.PreTrainedTokenizer,
+    prompts: List[str],
+    chosen_outputs: List[str],
+    rejected_outputs: List[str],
+    max_length: int = 512,
+    max_prompt_length: Optional[int] = None,
+    num_interventions: int = 1,
+) -> Dict:
+    """Build dataset and collator for ReFT DPO training from prompt/chosen/rejected lists."""
+    assert len(prompts) == len(chosen_outputs) == len(rejected_outputs)
+    train_dataset = datasets.Dataset.from_dict({
+        "prompt": prompts,
+        "chosen": chosen_outputs,
+        "rejected": rejected_outputs,
+    })
+    collator = ReftDPODataCollator(
+        tokenizer=tokenizer,
+        max_length=max_length,
+        max_prompt_length=max_prompt_length or max_length,
+        num_interventions=num_interventions,
+        pad_token_id=tokenizer.pad_token_id,
+    )
+    return dict(
+        train_dataset=train_dataset,
+        eval_dataset=None,
+        data_collator=collator,
+    )

--- a/pyreft/reft_trainer.py
+++ b/pyreft/reft_trainer.py
@@ -16,7 +16,7 @@ from transformers.trainer_utils import (
 )
 from datasets import Dataset
 from dataclasses import dataclass
-from typing import Dict, Optional, Sequence, Union, Iterable
+from typing import Dict, List, Literal, Optional, Sequence, Union, Iterable, Tuple
 
 from tqdm import tqdm
 import os
@@ -273,4 +273,127 @@ class ReftTrainerForSequenceClassification(ReftTrainer):
         self._memory_tracker.stop_and_update_metrics(metrics)
         
         return metrics
-        
+
+
+def _create_reft_dpo_trainer():
+    try:
+        from trl import DPOTrainer
+    except ImportError:
+        return None
+
+    class _ReftDPOTrainer(DPOTrainer):
+        def concatenated_forward(
+            self,
+            model: nn.Module,
+            batch: Dict[str, Union[List, torch.LongTensor]],
+            reference: bool = False,
+        ) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor, torch.Tensor]:
+            concatenated_batch = self.concatenated_inputs(
+                batch,
+                is_encoder_decoder=self.is_encoder_decoder,
+                label_pad_token_id=self.label_pad_token_id,
+                padding_value=self.padding_value,
+                device=self.accelerator.device,
+            )
+            len_chosen = batch["chosen_labels"].shape[0]
+            il = batch["intervention_locations"]
+            intervention_locations = torch.cat([il, il], dim=0).permute(1, 0, 2).tolist()
+
+            model_kwargs = (
+                {
+                    "labels": concatenated_batch["concatenated_labels"],
+                    "decoder_input_ids": concatenated_batch.pop("concatenated_decoder_input_ids", None),
+                }
+                if self.is_encoder_decoder
+                else {}
+            )
+            if reference:
+                all_outputs = model.model(
+                    input_ids=concatenated_batch["concatenated_input_ids"].to(model.get_device()),
+                    attention_mask=concatenated_batch["concatenated_attention_mask"].to(model.get_device()),
+                    use_cache=False,
+                    **model_kwargs,
+                )
+            else:
+                _, all_outputs = model(
+                    {
+                        "input_ids": concatenated_batch["concatenated_input_ids"].to(model.get_device()),
+                        "attention_mask": concatenated_batch["concatenated_attention_mask"].to(model.get_device()),
+                    },
+                    unit_locations={"sources->base": (None, intervention_locations)},
+                    use_cache=False,
+                    **model_kwargs,
+                )
+
+            all_logits = all_outputs.logits
+            all_logps = self.get_batch_logps(
+                all_logits,
+                concatenated_batch["concatenated_labels"],
+                average_log_prob=self.loss_type == "ipo",
+                is_encoder_decoder=self.is_encoder_decoder,
+                label_pad_token_id=self.label_pad_token_id,
+            )
+            chosen_logps = all_logps[:len_chosen]
+            rejected_logps = all_logps[len_chosen:]
+            chosen_logits = all_logits[:len_chosen]
+            rejected_logits = all_logits[len_chosen:]
+            return (chosen_logps, rejected_logps, chosen_logits, rejected_logits)
+
+        def get_batch_loss_metrics(
+            self,
+            model,
+            batch: Dict[str, Union[List, torch.LongTensor]],
+            train_eval: Literal["train", "eval"] = "train",
+        ):
+            metrics = {}
+            (
+                policy_chosen_logps,
+                policy_rejected_logps,
+                policy_chosen_logits,
+                policy_rejected_logits,
+            ) = self.concatenated_forward(model, batch, reference=False)
+
+            if "reference_chosen_logps" in batch and "reference_rejected_logps" in batch:
+                reference_chosen_logps = batch["reference_chosen_logps"]
+                reference_rejected_logps = batch["reference_rejected_logps"]
+            else:
+                with torch.no_grad():
+                    (
+                        reference_chosen_logps,
+                        reference_rejected_logps,
+                        _,
+                        _,
+                    ) = self.concatenated_forward(self.model, batch, reference=True)
+
+            losses, chosen_rewards, rejected_rewards = self.dpo_loss(
+                policy_chosen_logps,
+                policy_rejected_logps,
+                reference_chosen_logps,
+                reference_rejected_logps,
+            )
+            reward_accuracies = (chosen_rewards > rejected_rewards).float()
+            prefix = "eval_" if train_eval == "eval" else ""
+            metrics[f"{prefix}rewards/chosen"] = chosen_rewards.mean().cpu()
+            metrics[f"{prefix}rewards/rejected"] = rejected_rewards.mean().cpu()
+            metrics[f"{prefix}rewards/accuracies"] = reward_accuracies.mean().cpu()
+            metrics[f"{prefix}rewards/margins"] = (chosen_rewards - rejected_rewards).mean().cpu()
+            metrics[f"{prefix}logps/rejected"] = policy_rejected_logps.detach().mean().cpu()
+            metrics[f"{prefix}logps/chosen"] = policy_chosen_logps.detach().mean().cpu()
+            metrics[f"{prefix}logits/rejected"] = policy_rejected_logits.detach().mean().cpu()
+            metrics[f"{prefix}logits/chosen"] = policy_chosen_logits.detach().mean().cpu()
+            return losses.mean(), metrics
+
+        def save_model(self, output_dir: Optional[str] = None, _internal_call: bool = False):
+            if output_dir is None:
+                output_dir = self.args.output_dir
+            if not os.path.exists(output_dir):
+                os.makedirs(output_dir)
+            self.model.save_intervention(
+                save_directory=os.path.join(output_dir, "intervenable_model"),
+                include_model=True,
+            )
+
+    return _ReftDPOTrainer
+
+
+ReftDPOTrainer = _create_reft_dpo_trainer()

--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ setup(
     packages=find_packages(include=['pyreft', 'pyreft.*']),
     python_requires='>=3.8',
     install_requires=requirements,
-    extras_require={},
+    extras_require={"dpo": ["trl"]},
     classifiers=[
         "Development Status :: 3 - Alpha",
         "Intended Audience :: Science/Research",

--- a/tests/test_marker_and_dpo.py
+++ b/tests/test_marker_and_dpo.py
@@ -1,0 +1,132 @@
+import pytest
+
+pytest.importorskip("pyvene")
+pytest.importorskip("transformers")
+
+from pyreft.dataset import (
+    _parse_marker_spans,
+    _span_ranges_to_token_indices,
+    make_marker_supervised_data_module,
+    make_dpo_data_module,
+    ReftDPODataCollator,
+)
+
+
+class TestParseMarkerSpans:
+    def test_single_span(self):
+        text = "Hello <<reft>> world </reft>> here"
+        cleaned, spans = _parse_marker_spans(text)
+        assert cleaned == "Hello world here"
+        assert spans == [(6, 11)]
+
+    def test_no_marker(self):
+        text = "Hello world"
+        cleaned, spans = _parse_marker_spans(text)
+        assert cleaned == "Hello world"
+        assert spans == []
+
+    def test_two_spans(self):
+        text = "A <<reft>> one </reft>> B <<reft>> two </reft>> C"
+        cleaned, spans = _parse_marker_spans(text)
+        assert cleaned == "A one B two C"
+        assert spans == [(2, 5), (8, 11)]
+
+    def test_custom_markers(self):
+        text = "x [s] foo [/s] y"
+        cleaned, spans = _parse_marker_spans(text, start_marker="[s]", end_marker="[/s]")
+        assert cleaned == "x foo y"
+        assert spans == [(2, 5)]
+
+
+class TestMarkerSupervisedDataModule:
+    @pytest.fixture
+    def tokenizer_and_model(self):
+        from transformers import AutoTokenizer, AutoModelForCausalLM
+        name = "gpt2"
+        tokenizer = AutoTokenizer.from_pretrained(name)
+        tokenizer.pad_token = tokenizer.eos_token
+        model = AutoModelForCausalLM.from_pretrained(name)
+        return tokenizer, model
+
+    def test_marker_data_module_structure(self, tokenizer_and_model):
+        tokenizer, model = tokenizer_and_model
+        inputs = ["Say <<reft>> hello </reft>>.", "No markers here."]
+        outputs = ["Hi", "Bye"]
+        out = make_marker_supervised_data_module(
+            tokenizer, model, inputs, outputs, num_interventions=1
+        )
+        assert "train_dataset" in out
+        assert "data_collator" in out
+        ds = out["train_dataset"]
+        assert len(ds) == 2
+        assert "input_ids" in ds.column_names
+        assert "intervention_locations" in ds.column_names
+        assert "labels" in ds.column_names
+
+    def test_marker_intervention_locations_in_bounds(self, tokenizer_and_model):
+        tokenizer, model = tokenizer_and_model
+        inputs = ["<<reft>> hello </reft>>"]
+        outputs = [" world"]
+        out = make_marker_supervised_data_module(
+            tokenizer, model, inputs, outputs, num_interventions=1
+        )
+        row = out["train_dataset"][0]
+        seq_len = len(row["input_ids"])
+        for loc_list in row["intervention_locations"]:
+            for idx in loc_list:
+                assert 0 <= idx < seq_len or idx == -1
+
+
+class TestSpanRangesToTokenIndices:
+    def test_basic(self):
+        from transformers import AutoTokenizer
+        tokenizer = AutoTokenizer.from_pretrained("gpt2")
+        text = "Hello world"
+        spans = [(0, 5)]
+        indices = _span_ranges_to_token_indices(tokenizer, text, spans)
+        assert len(indices) == 1
+        assert len(indices[0]) >= 1
+        assert all(0 <= i for i in indices[0])
+
+
+class TestDPODataModule:
+    @pytest.fixture
+    def tokenizer(self):
+        from transformers import AutoTokenizer
+        t = AutoTokenizer.from_pretrained("gpt2")
+        t.pad_token = t.eos_token
+        return t
+
+    def test_make_dpo_data_module_structure(self, tokenizer):
+        prompts = ["Q: 1+1? A:", "Q: 2+2? A:"]
+        chosen = [" 2", " 4"]
+        rejected = [" 3", " 5"]
+        out = make_dpo_data_module(
+            tokenizer, prompts, chosen, rejected,
+            max_length=64, num_interventions=1
+        )
+        assert "train_dataset" in out
+        assert "data_collator" in out
+        ds = out["train_dataset"]
+        assert len(ds) == 2
+        assert "prompt" in ds.column_names
+        assert "chosen" in ds.column_names
+        assert "rejected" in ds.column_names
+
+    def test_dpo_collator_output_shape(self, tokenizer):
+        collator = ReftDPODataCollator(
+            tokenizer=tokenizer,
+            max_length=32,
+            num_interventions=1,
+            pad_token_id=tokenizer.pad_token_id,
+        )
+        features = [
+            {"prompt": "Q: x? A:", "chosen": " yes", "rejected": " no"},
+            {"prompt": "Q: y? A:", "chosen": " no", "rejected": " yes"},
+        ]
+        batch = collator(features)
+        assert batch["chosen_input_ids"].shape[0] == 2
+        assert batch["rejected_input_ids"].shape[0] == 2
+        assert batch["intervention_locations"].shape[0] == 2
+        assert "chosen_labels" in batch
+        assert "rejected_labels" in batch


### PR DESCRIPTION
## Summary
This PR introduces marker-based intervention targeting and first-class DPO support for ReFT.

### Marker-based intervention positions
Users can wrap spans in prompts using:

<<reft>> ... </reft>>

Markers are stripped before the model input and intervention locations are automatically mapped to the corresponding token indices. Optionally, only the last token of each span can be used.

### First-class ReFT DPO
Adds native DPO support for preference training with ReFT interventions.

Components added:
- ReftDPOTrainer
- ReftDPODataCollator
- make_dpo_data_module

trl can be installed via:

pip install pyreft[dpo]

## Changes
dataset.py
- _parse_marker_spans
- _span_ranges_to_token_indices
- make_marker_supervised_data_module
- ReftDPODataCollator
- make_dpo_data_module

reft_trainer.py
- ReftDPOTrainer

setup.py
- extras_require={"dpo": ["trl"]}

tests/
- marker parsing tests
- dataset tests
- DPO collator tests

## Authors
- Ireddi Rakshitha
- Yashwanth Devavarapu
